### PR TITLE
Update github releases URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Contents:
 
 # Installation
 
-Official release executable binaries can be downloaded via [Github releases](https://github.com/cloudfoundry-incubator/spiff/releases) for Darwin and Linux machines (and virtual machines).
+Official release executable binaries can be downloaded via [Github releases](https://github.com/mandelsoft/spiff/releases) for Darwin and Linux machines (and virtual machines).
 
 Some of spiff's dependencies have changed since the last official release, and spiff will not be updated to keep up with these dependencies.  Working dependencies are vendored in the `Godeps` directory (more information on the `godep` tool is available [here](https://github.com/tools/godep)).  As such, trying to `go get` spiff will likely fail; the only supported way to use spiff is to use an official binary release.
 


### PR DESCRIPTION
After starting to get familiar with the tool, I realized that a big portion of the README examples didn't work. After a couple of days of investigation, I noticed that by following the _Installation_ from the README, I have installed the 3 years old version. The URL points to the `spiff` releases and not to `spiff++`.