### PR TITLE
candiedyaml: honour !!str tag in resolveInterface to prevent YAML 1.1 bool coercion

### DIFF
--- a/legacy/candiedyaml/resolver.go
+++ b/legacy/candiedyaml/resolver.go
@@ -368,6 +368,14 @@ func resolveInterface(event yaml_event_t, useNumber bool) (string, interface{}) 
 		return "", val
 	}
 
+	// Honour an explicit !!str tag: the YAML spec requires that an explicit
+	// tag overrides implicit type resolution. Without this guard, values like
+	// `!!str off` or `!!str yes` are still coerced to booleans because the
+	// character-based dispatch below does not check the tag.
+	if string(event.tag) == yaml_STR_TAG {
+		return yaml_STR_TAG, val
+	}
+
 	if len(val) == 0 {
 		return yaml_NULL_TAG, nil
 	}

--- a/legacy/candiedyaml/resolver_test.go
+++ b/legacy/candiedyaml/resolver_test.go
@@ -661,5 +661,21 @@ var _ = Describe("Resolver", func() {
 				Expect(tag).To(Equal(""))
 			})
 		})
+
+		Context("Explicit !!str tag preserves string (no bool coercion)", func() {
+			strTagBoolTokens := []string{"on", "ON", "off", "OFF", "yes", "YES", "no", "NO", "true", "TRUE", "false", "FALSE", "y", "Y", "n", "N"}
+
+			It("returns the raw string for each YAML 1.1 bool token tagged !!str", func() {
+				for _, tok := range strTagBoolTokens {
+					event.value = []byte(tok)
+					event.tag = []byte(yaml_STR_TAG)
+					event.implicit = false
+
+					tag, result := resolveInterface(event, false)
+					Expect(tag).To(Equal(yaml_STR_TAG), "token %q: expected tag !!str", tok)
+					Expect(result).To(Equal(tok), "token %q: expected string, not bool", tok)
+				}
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Problem

`resolveInterface` in `legacy/candiedyaml/resolver.go` ignores an explicit `!!str` tag when dispatching scalar values. A scalar such as `!!str off` has `event.tag = "tag:yaml.org,2002:str"` and `event.implicit = false`, but the existing guard at line 367:

```go
if len(event.tag) == 0 && !event.implicit {
    return "", val
}
```

does **not** fire — because `len(event.tag) != 0`. The function then falls through to the character-based type dispatch, where `'o'` matches the `bools` byte set and `resolve_bool("off")` succeeds, returning `(yaml_BOOL_TAG, false)`.

The result: any YAML emitter that writes `!!str off` (the standard way to protect a YAML 1.1 boolean-colliding value) produces data that candiedyaml decodes as `bool(false)` instead of `string("off")`. Any downstream code relying on string semantics (`jq` paths like `.config.basic_auth_handling // "default"`, string comparisons) then silently fails.

## Fix

Add an early-return guard for the `!!str` tag immediately after the existing implicit/no-tag guard:

```go
// Honour an explicit !!str tag: the YAML spec requires that an explicit
// tag overrides implicit type resolution.
if string(event.tag) == yaml_STR_TAG {
    return yaml_STR_TAG, val
}
```

This is a 3-line change. All other type dispatch (int, float, bool, null, binary, timestamp) is unchanged.

The `resolve()` function for typed decodes is unaffected — it dispatches on the target Go `reflect.Kind` before calling `resolveInterface`, so `resolve_bool` still handles `!!bool off` and decoding `!!str off` into a `bool` field still returns the expected error.

## Tests

Adds a new Ginkgo context `"Explicit !!str tag preserves string (no bool coercion)"` in `resolver_test.go` covering all 16 YAML 1.1 boolean tokens (`on`, `ON`, `off`, `OFF`, `yes`, `YES`, `no`, `NO`, `true`, `TRUE`, `false`, `FALSE`, `y`, `Y`, `n`, `N`) tagged with `!!str`.

Fixes #38